### PR TITLE
Volumetric DTFE density estimation, documentation

### DIFF
--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install numpy
-          python -m pip install Sphinx sphinx-rtd-theme sphinxcontrib-napoleon numpydoc
+          python -m pip install Sphinx sphinx-rtd-theme sphinxcontrib-napoleon numpydoc myst-parser
           python -m pip install .
       - name: Debugging information
         run: |

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -1,0 +1,144 @@
+name: sphinx
+on: [push, pull_request]
+
+env:
+  DEFAULT_BRANCH: "master"
+  SPHINXOPTS: "-W --keep-going -T"
+  # ^-- If these SPHINXOPTS are enabled, then be strict about the builds and fail on any warnings
+
+jobs:
+  build-and-deploy:
+    name: Build and gh-pages
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/checkout
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          lfs: true
+      # https://github.com/marketplace/actions/setup-python
+      # ^-- This gives info on matrix testing.
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+      # https://docs.github.com/en/actions/guides/building-and-testing-python#caching-dependencies
+      # ^-- How to set up caching for pip on Ubuntu
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      # https://docs.github.com/en/actions/guides/building-and-testing-python#installing-dependencies
+      # ^-- This gives info on installing dependencies with pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install numpy
+          python -m pip install Sphinx sphinx-rtd-theme sphinxcontrib-napoleon numpydoc
+          python -m pip install .
+      - name: Debugging information
+        run: |
+          echo "github.ref:" ${{github.ref}}
+          echo "github.event_name:" ${{github.event_name}}
+          echo "github.head_ref:" ${{github.head_ref}}
+          echo "github.base_ref:" ${{github.base_ref}}
+          set -x
+          git rev-parse --abbrev-ref HEAD
+          git branch
+          git branch -a
+          git remote -v
+          python -V
+          pip list --not-required
+          pip list
+      # Build
+      - uses: ammaraskar/sphinx-problem-matcher@master
+      - name: Build Sphinx docs
+        working-directory: ./docs
+        run: |
+          make dirhtml
+          # This fixes broken copy button icons, as explained in
+          #   https://github.com/coderefinery/sphinx-lesson/issues/50
+          #   https://github.com/executablebooks/sphinx-copybutton/issues/110
+          # This can be removed once these PRs are accepted (but the
+          # fixes also need to propagate to other themes):
+          #   https://github.com/sphinx-doc/sphinx/pull/8524
+          #   https://github.com/readthedocs/sphinx_rtd_theme/pull/1025
+          sed -i 's/url_root="#"/url_root=""/' _build/dirhtml/index.html || true
+      # The following supports building all branches and combining on
+      # gh-pages
+
+      # Clone and set up the old gh-pages branch
+      - name: Clone old gh-pages
+        if: ${{ github.event_name == 'push' }}
+        working-directory: ./docs
+        run: |
+          set -x
+          git fetch
+          ( git branch gh-pages remotes/origin/gh-pages && git clone . --branch=gh-pages _gh-pages/ ) || mkdir _gh-pages
+          rm -rf _gh-pages/.git/
+          mkdir -p _gh-pages/branch/
+      # If a push and default branch, copy build to _gh-pages/ as the "main"
+      # deployment.
+      - name: Copy new build (default branch)
+        if: |
+          contains(github.event_name, 'push') &&
+          contains(github.ref, env.DEFAULT_BRANCH)
+        working-directory: ./docs
+        run: |
+          set -x
+          # Delete everything under _gh-pages/ that is from the
+          # primary branch deployment.  Eicludes the other branches
+          # _gh-pages/branch-* paths, and not including
+          # _gh-pages itself.
+          find _gh-pages/ -mindepth 1 ! -path '_gh-pages/branch*' -delete
+          rsync -a _build/dirhtml/ _gh-pages/
+      # If a push and not on default branch, then copy the build to
+      # _gh-pages/branch/$brname (transforming '/' into '--')
+      - name: Copy new build (branch)
+        if: |
+          contains(github.event_name, 'push') &&
+          !contains(github.ref, env.DEFAULT_BRANCH)
+        working-directory: ./docs
+        run: |
+          set -x
+          #brname=$(git rev-parse --abbrev-ref HEAD)
+          brname="${{github.ref}}"
+          brname="${brname##refs/heads/}"
+          brdir=${brname//\//--}   # replace '/' with '--'
+          rm -rf   _gh-pages/branch/${brdir}
+          rsync -a _build/dirhtml/ _gh-pages/branch/${brdir}
+      # Go through each branch in _gh-pages/branch/, if it's not a
+      # ref, then delete it.
+      - name: Delete old feature branches
+        if: ${{ github.event_name == 'push' }}
+        working-directory: ./docs
+        run: |
+          set -x
+          for brdir in `ls _gh-pages/branch/` ; do
+              brname=${brdir//--/\/}   # replace '--' with '/'
+              if ! git show-ref remotes/origin/$brname ; then
+                  echo "Removing $brdir"
+                  rm -r _gh-pages/branch/$brdir/
+              fi
+          done
+      # Add the .nojekyll file
+      - name: nojekyll
+        if: ${{ github.event_name == 'push' }}
+        working-directory: ./docs
+        run: |
+          touch _gh-pages/.nojekyll
+      # Deploy
+      # https://github.com/peaceiris/actions-gh-pages
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.event_name == 'push' }}
+        #if: ${{ success() && github.event_name == 'push' && github.ref == 'refs/heads/$defaultBranch' }}
+        with:
+          publish_branch: gh-pages
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/_gh-pages/
+          force_orphan: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 *.o
+test_py/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build/
 *.o
 test_py/
+.vscode
+docs/_build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ if(NOT libtiff_POPULATED)
 endif()
 
 # OpenMP  (if found: OpenMP_FOUND)
-# find_package(OpenMP)
+find_package(OpenMP)
 
 # set sources
 set(sources

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ FetchContent_Declare(
 FetchContent_GetProperties(qhull)
 if(NOT qhull_POPULATED)
     FetchContent_Populate(qhull)
+    # patch incorrect cmake_source_dir in qhull
+    execute_process(COMMAND sed -i "s@CMAKE_SOURCE_DIR@CMAKE_CURRENT_SOURCE_DIR@g" ${qhull_SOURCE_DIR}/CMakeLists.txt)
     add_subdirectory(${qhull_SOURCE_DIR} ${qhull_BINARY_DIR})
 endif()
 
@@ -54,7 +56,7 @@ set(sources
 add_library(libdtfe STATIC ${sources})
 add_library(dtfe::libdtfe ALIAS libdtfe)
 target_include_directories(libdtfe INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/src")
-target_include_directories(libdtfe PRIVATE ${qhull_SOURCE_DIR}/src/libqhull)
+target_include_directories(libdtfe PRIVATE ${qhull_SOURCE_DIR}/src/libqhull ${qhull_SOURCE_DIR}/src/libqhull_r)
 target_link_libraries(libdtfe PRIVATE qhullstatic tiff ${M_LIBRARIES})
 if(OpenMP_FOUND)
     target_link_libraries(libdtfe PRIVATE OpenMP::OpenMP_C)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,9 +7,9 @@ set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Sanitizer
-# set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
-# set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
-# set (CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
+# set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer -fsanitize=address -g")
+# set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer -fsanitize=address -g")
+# set (CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address -g")
 
 # Load QHULL
 include(FetchContent)

--- a/README.md
+++ b/README.md
@@ -1,21 +1,57 @@
 # SDTFE
-This code implements the method for computing a surface density field from particle data, as described in the paper: Parallel DTFE Surface Density Field Reconstruction, see author section for details. It was developed for computing gravitational lensing effects using the flat-sky approximation from N-body cosmological simulations.  
+This code implements the method for computing a surface density field from particle data, as described in the paper: Parallel DTFE Surface Density Field Reconstruction, see author section for details. It was developed for computing gravitational lensing effects using the flat-sky approximation from N-body cosmological simulations.
 
-## Getting Started
+## Installation
 
-These instructions will get a copy of the project up and running on your local machine for development and testing purposes. Tested on macOSX 10.13.3 High Sierra. 
+These instructions will get a copy of the project up and running on your local machine for development and testing purposes. Tested on macOSX 10.13.3 High Sierra.
 
-### Prerequisites
+Download SDTFE
+```bash
+git clone git@github.com:steverangel/SDTFE.git
+```
 
-This software uses [Qhull](http://www.qhull.org) for the Delaunay triangulation library. 
+### Building Using C-Make
 
-Optional, but recomended, is [libtiff](http://www.libtiff.org) for visualization of the resulting field. 
+CMake will automatically download the Qhull and libtiff dependencies.
 
-### Installing
+Prerequisites:
+
+- CMake v3.11 or later
+- compiler supporting C++14 (for the python extension)
+
+**Python library**
+
+The python library can be installed with ``pip`` from within the SDTFE folder.
+The ``setup.py`` script will internally call CMake to compile the DTFE library
+
+```bash
+cd SDTFE
+pip install .
+```
+
+
+**Executables**
+
+To build the executables, create a build directory and run ``cmake``
+
+```bash
+cd SDTFE
+mkdir build && cd build
+cmake ..
+make -j4
+```
+
+### Building Using Make
+
+Prerequisites:
+
+- This software uses [Qhull](http://www.qhull.org) for the Delaunay triangulation library.
+- Optional, but recomended, is [libtiff](http://www.libtiff.org) for visualization of the resulting field.
+
 
 Download and install Qhull.
 
-```
+```bash
 git clone git@github.com:qhull/qhull.git
 cd qhull
 make
@@ -23,7 +59,7 @@ make
 
 Download and install libtiff.
 
-```
+```bash
 curl -O http://download.osgeo.org/libtiff/tiff-4.0.9.tar.gz
 tar xvfz tiff-4.0.9.tar.gz
 cd tiff-4.0.9/
@@ -33,19 +69,13 @@ make
 make install
 ```
 
-Download SDTFE.
-
-```
-git clone git@github.com:steverangel/SDTFE.git
-```
-
 Edit the SDTFE Makefile to link Qhull and libtiff.
 
 ```
 cd SDTFE
 vim Makefile
 ...
-QHULLLIBDIR = ../qhull/lib 
+QHULLLIBDIR = ../qhull/lib
 QHULLINCDIR = -I../qhull/src/libqhull
 
 TIFFLIBDIR = ../tiff-4.0.9/install/lib
@@ -55,40 +85,18 @@ TIFFINCDIR = -I../tiff-4.0.9/libtiff
 
 Compile SDTFE using make.
 
-```
+```bash
 make
 ```
 
-## Running the examples
-
-Download and extract example data.
-
-```
-curl -O http://users.eecs.northwestern.edu/~emr126/sdtfe_examples.tar.gz
-tar xvfz sdtfe_examples.tar.gz
-```
-
-Run the examples with all the parameters.
-
-Usage: dtfe [ path\_to\_file n\_particles grid\_dim center\_x center\_y center\_z field\_width field\_depth particle\_mass mc\_box\_width n\_mc\_samples sample\_factor ]
-
-```
-./bin/dtfe ../data/913571938961.bin 216683 768 2556.9 1510.4 1986.6 6.0 4.0 1 0.01 5 0.25
-```
-
-Or by terminal prompts.
-
-```
-./bin/dtfe
-```
-
+--------------------------------------------------------------------------------
 ## Authors
 
 * **Esteban Rangel** - *Parallel DTFE Surface Density Field Reconstruction* - [pdf](http://cucis.ece.northwestern.edu/publications/pdf/RLH16.pdf)
 
 ## License
 
-This project is licensed under the GNU License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the GNU License - see the [LICENSE](https://github.com/steverangel/SDTFE/blob/master/LICENSE) file for details.
 
 ## Acknowledgments
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,0 +1,7 @@
+table.full-width {
+    width: 100%;
+}
+
+table.full-width td {
+    white-space: normal !important;
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,101 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+#
+
+import os, sys, shutil, subprocess
+import re
+from pathlib import Path
+
+DIR = Path(__file__).parent.resolve()
+
+
+# -- Project information -----------------------------------------------------
+
+project = "SDTFE"
+copyright = "2022, Steve Rangel, et al."
+author = "Steve Rangel, et al."
+
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    "sphinx.ext.doctest",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.autodoc.typehints",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.viewcode",
+    "sphinx.ext.autosectionlabel",
+    "myst_parser",
+]
+
+autosectionlabel_prefix_document = True
+
+autodoc_typehints = "description"
+add_module_names = False
+
+autosummary_generate = False
+napoleon_numpy_docstring = True
+napoleon_use_admonition_for_examples = True
+napoleon_use_admonition_for_notes = True
+
+source_suffix = {".rst": "restructuredtext", ".md": "markdown"}
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "README.md"]
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = "sphinx_rtd_theme"
+html_theme_options = {"prev_next_buttons_location": None}
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ["_static"]
+
+
+def prepare(app):
+    with open(DIR.parent / "README.md") as f:
+        contents = f.read()
+
+    # Filter out section titles for index.rst for LaTeX
+    if app.builder.name == "latex":
+        contents = re.sub(r"^(.*)\n[-~]{3,}$", r"**\1**", contents, flags=re.MULTILINE)
+
+    with open(DIR / "README.md", "w") as f:
+        f.write(contents)
+
+
+def clean_up(app, exception):
+    (DIR / "README.md").unlink()
+
+
+def setup(app):
+    app.add_css_file("css/custom.css")
+    # Copy the readme in
+    app.connect("builder-inited", prepare)
+
+    # Clean up the generated readme
+    app.connect("build-finished", clean_up)

--- a/docs/executables.rst
+++ b/docs/executables.rst
@@ -1,0 +1,34 @@
+Executables
+===========
+
+Example Data
+------------
+
+Download and extract example data.
+
+.. code-block:: bash
+
+   curl -O http://users.eecs.northwestern.edu/~emr126/sdtfe_examples.tar.gz
+   tar xvfz sdtfe_examples.tar.gz
+
+
+
+dtfe
+----
+
+.. code-block::
+
+   Usage: dtfe [ path\_to\_file n\_particles grid\_dim center\_x center\_y center\_z field\_width field\_depth particle\_mass mc\_box\_width n\_mc\_samples sample\_factor ]
+
+Run the examples with all the parameters specified:
+
+.. code-block:: bash
+
+   ./bin/dtfe ../data/913571938961.bin 216683 768 2556.9 1510.4 1986.6 6.0 4.0 1 0.01 5 0.25
+
+
+Or by terminal prompts:
+
+.. code-block:: bash
+
+   ./bin/dtfe

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,23 @@
+.. SDTFE documentation master file, created by
+   sphinx-quickstart on Thu Jan 13 17:25:19 2022.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+.. only:: latex
+
+   ===================
+   SDTFE Documentation
+   ===================
+
+.. include:: README.md
+   :parser: myst_parser.sphinx_
+
+
+.. only:: latex
+
+   .. toctree::
+      :maxdepth: 2
+
+      self
+      python.rst
+      executables.rst

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/python.rst
+++ b/docs/python.rst
@@ -1,0 +1,10 @@
+SDTFE Python Library
+====================
+.. currentmodule:: pydtfe
+
+References
+----------
+
+.. autofunction:: compute_surface_density
+
+.. autofunction:: compute_3d_density

--- a/python/pydtfe.cpp
+++ b/python/pydtfe.cpp
@@ -144,15 +144,17 @@ PYBIND11_MODULE(pydtfe, m) {
             mass of a single particle
 
         mc_box_width: float
+           width of monte-carlo sampling of rays in each surface cell
 
         mc_sample_count: int
+           number of monte-carlo samples to be drawn per cell
 
         rotation_angle: Optional[List[float]]
 
         Returns
         -------
         rho: np.ndarray
-            the surface density map, in units of ``particle_mass / box_width^2``
+            the surface density map, in units of ``mass / length^2``
             (shape: ``(grid_dim, grid_dim)``)
   )Delim",
         py::arg("particle_pos"),
@@ -203,7 +205,7 @@ PYBIND11_MODULE(pydtfe, m) {
         Returns
         -------
         rho: np.ndarray
-            the volumetric density map, in units of ``particle_mass / box_width^3``
+            the volumetric density map, in units of ``mass / length^3``
             (shape: ``(grid_dim, grid_dim, grid_dim)``)
   )Delim",
         py::arg("particle_pos"),

--- a/python/pydtfe.cpp
+++ b/python/pydtfe.cpp
@@ -26,9 +26,9 @@ py::array_t<double> compute_density_py(
     std::optional<std::array<double, 3>> rotation_angle
 ) {
     // convert to qhdata
-    std::cout << "Particle position dim: " << particle_pos.ndim() << std::endl;
-    std::cout << "Particle position shape: " << particle_pos.shape(0) << ", " << particle_pos.shape(1) << std::endl;
-    std::cout << "Particle position flags: " << particle_pos.flags() << std::endl;
+    // std::cout << "Particle position dim: " << particle_pos.ndim() << std::endl;
+    // std::cout << "Particle position shape: " << particle_pos.shape(0) << ", " << particle_pos.shape(1) << std::endl;
+    // std::cout << "Particle position flags: " << particle_pos.flags() << std::endl;
     if(particle_pos.shape(1) != 3) {
         throw py::value_error("incorrect shape of particle position array");
     }
@@ -45,7 +45,7 @@ py::array_t<double> compute_density_py(
         rotate3d(particle_data, n_shuffle, rotation_angle->data(), center.data());
     }
 
-    std::cout << "Calling QHULL with " << n_shuffle << " particles (originally " << n_particles << ")" << std::endl;
+    // std::cout << "Calling QHULL with " << n_shuffle << " particles (originally " << n_particles << ")" << std::endl;
     // triangulate
     size_t n_tetra;
     int *tetra_data = triangulate(particle_data, n_shuffle, &n_tetra, "qhull d Qz Qt Qbb");
@@ -62,9 +62,92 @@ py::array_t<double> compute_density_py(
     return rho;
 }
 
+py::array_t<double> compute_3d_density_py(
+    py::array_t<float, py::array::f_style | py::array::forcecast> particle_pos,
+    std::array<double, 3> center,
+    unsigned grid_dim,
+    float sample_factor,
+    double box_length,
+    double particle_mass
+) {
+    // convert to qhdata
+    // std::cout << "Particle position dim: " << particle_pos.ndim() << std::endl;
+    // std::cout << "Particle position shape: " << particle_pos.shape(0) << ", " << particle_pos.shape(1) << std::endl;
+    // std::cout << "Particle position flags: " << particle_pos.flags() << std::endl;
+    if(particle_pos.shape(1) != 3) {
+        throw py::value_error("incorrect shape of particle position array");
+    }
+    size_t n_particles = particle_pos.shape(0);
+    double *particle_data = convert_to_qhdata(particle_pos.data(), n_particles);
+
+    // shuffle and rotate
+    size_t n_shuffle = n_particles*sample_factor;
+    if(n_shuffle < 5) {
+        throw py::value_error("not enough particles");
+    }
+    shuffle_buff(particle_data, n_particles, n_shuffle);
+
+    // std::cout << "Calling QHULL with " << n_shuffle << " particles (originally " << n_particles << ")" << std::endl;
+    // triangulate
+    size_t n_tetra;
+    int *tetra_data = triangulate(particle_data, n_shuffle, &n_tetra, "qhull d Qz Qt Qbb");
+
+    // calculate density
+    py::array_t<double> rho({grid_dim, grid_dim, grid_dim});
+    std::fill(rho.mutable_data(), rho.mutable_data() + grid_dim*grid_dim, 0.);
+    compute_3d_density(particle_data, n_shuffle, tetra_data, n_tetra, grid_dim, box_length, rho.mutable_data(), particle_mass, center[0], center[1], center[2]);
+
+    // cleanup
+    free(tetra_data);
+    free(particle_data);
+
+    return rho;
+}
+
 PYBIND11_MODULE(pydtfe, m) {
     m.doc() = "python interface to SDTFE";
-    m.def("compute_surface_density", &compute_density_py,
+    m.def("compute_surface_density", &compute_density_py, R"Delim(
+        computes the surface density using the DTFE tesselation of a particle
+        distribution
+
+        Parameters
+        ----------
+        particle_pos: np.ndarray
+            3d positions of the particles (shape ``(N, 3)``)
+
+        center: List[float]
+            position of the halo center (length 3)
+
+        grid_dim: int
+            resolution of the surface density map (will be square)
+
+        sample_factor: float
+            subsampling factor between [0, 1]. If smaller than 1.0, the code
+            will only use a random subset of the particles, corresponding to
+            the fraction specified
+
+        box_width: float
+            physical size of the width (and height) of the map
+
+        box_depth: float
+            physical depth of the surface density map (density will be
+            integrated between [center_z - box_depth/2, center_z + box_depth/2])
+
+        particle_mass: float
+            mass of a single particle
+
+        mc_box_width: float
+
+        mc_sample_count: int
+
+        rotation_angle: Optional[List[float]]
+
+        Returns
+        -------
+        rho: np.ndarray
+            the surface density map, in units of ``particle_mass / box_width^2``
+            (shape: ``(grid_dim, grid_dim)``)
+  )Delim",
         py::arg("particle_pos"),
         py::arg("center"),
         py::arg("grid_dim"),
@@ -75,5 +158,45 @@ PYBIND11_MODULE(pydtfe, m) {
         py::arg("mc_box_width"),
         py::arg("mc_sample_count"),
         py::arg("rotation_angle") = nullptr
-        );
+    );
+
+    m.def("compute_3d_density", &compute_3d_density_py, R"Delim(
+        computes the volumetric density using the DTFE tesselation of a particle
+        distribution
+
+        Parameters
+        ----------
+        particle_pos: np.ndarray
+            3d positions of the particles (shape ``(N, 3)``)
+
+        center: List[float]
+            position of the halo center (length 3)
+
+        grid_dim: int
+            resolution of the density map (will be a cube)
+
+        sample_factor: float
+            subsampling factor between [0, 1]. If smaller than 1.0, the code
+            will only use a random subset of the particles, corresponding to
+            the fraction specified
+
+        box_depth: float
+            physical size of the density cube
+
+        particle_mass: float
+            mass of a single particle
+
+        Returns
+        -------
+        rho: np.ndarray
+            the volumetric density map, in units of ``particle_mass / box_width^3``
+            (shape: ``(grid_dim, grid_dim, grid_dim)``)
+  )Delim",
+        py::arg("particle_pos"),
+        py::arg("center"),
+        py::arg("grid_dim"),
+        py::arg("sample_factor"),
+        py::arg("box_length"),
+        py::arg("particle_mass")
+    );
 }

--- a/python/pydtfe.cpp
+++ b/python/pydtfe.cpp
@@ -114,49 +114,49 @@ py::array_t<double> compute_3d_density_py(
 PYBIND11_MODULE(pydtfe, m) {
     m.doc() = "python interface to SDTFE";
     m.def("compute_surface_density", &compute_density_py, R"Delim(
-        computes the surface density using the DTFE tesselation of a particle
-        distribution
+computes the surface density using the DTFE tesselation of a particle
+distribution
 
-        Parameters
-        ----------
-        particle_pos: np.ndarray
-            3d positions of the particles (shape ``(N, 3)``)
+Parameters
+----------
+particle_pos: np.ndarray
+    3d positions of the particles (shape ``(N, 3)``)
 
-        center: List[float]
-            position of the halo center (length 3)
+center: List[float]
+    position of the halo center (length 3)
 
-        grid_dim: int
-            resolution of the surface density map (will be square)
+grid_dim: int
+    resolution of the surface density map (will be square)
 
-        sample_factor: float
-            subsampling factor between [0, 1]. If smaller than 1.0, the code
-            will only use a random subset of the particles, corresponding to
-            the fraction specified
+sample_factor: float
+    subsampling factor between [0, 1]. If smaller than 1.0, the code will only
+    use a random subset of the particles, corresponding to the fraction
+    specified
 
-        box_width: float
-            physical size of the width (and height) of the map
+box_width: float
+    physical size of the width (and height) of the map
 
-        box_depth: float
-            physical depth of the surface density map (density will be
-            integrated between [center_z - box_depth/2, center_z + box_depth/2])
+box_depth: float
+    physical depth of the surface density map (density will be integrated
+    between [center_z - box_depth/2, center_z + box_depth/2])
 
-        particle_mass: float
-            mass of a single particle
+particle_mass: float
+    mass of a single particle
 
-        mc_box_width: float
-           width of monte-carlo sampling of rays in each surface cell
+mc_box_width: float
+    width of monte-carlo sampling of rays in each surface cell
 
-        mc_sample_count: int
-           number of monte-carlo samples to be drawn per cell
+mc_sample_count: int
+    number of monte-carlo samples to be drawn per cell
 
-        rotation_angle: Optional[List[float]]
+rotation_angle: Optional[List[float]]
 
-        Returns
-        -------
-        rho: np.ndarray
-            the surface density map, in units of ``mass / length^2``
-            (shape: ``(grid_dim, grid_dim)``)
-  )Delim",
+Returns
+-------
+rho: np.ndarray
+    the surface density map, in units of ``mass / length^2``
+    (shape: ``(grid_dim, grid_dim)``)
+)Delim",
         py::arg("particle_pos"),
         py::arg("center"),
         py::arg("grid_dim"),
@@ -170,44 +170,44 @@ PYBIND11_MODULE(pydtfe, m) {
     );
 
     m.def("compute_3d_density", &compute_3d_density_py, R"Delim(
-        computes the volumetric density using the DTFE tesselation of a particle
-        distribution
+computes the volumetric density using the DTFE tesselation of a particle
+distribution
 
-        Parameters
-        ----------
-        particle_pos: np.ndarray
-            3d positions of the particles (shape ``(N, 3)``)
+Parameters
+----------
+particle_pos: np.ndarray
+    3d positions of the particles (shape ``(N, 3)``)
 
-        center: List[float]
-            position of the halo center (length 3)
+center: List[float]
+    position of the halo center (length 3)
 
-        grid_dim: int
-            resolution of the density map (will be a cube)
+grid_dim: int
+    resolution of the density map (will be a cube)
 
-        sample_factor: float
-            subsampling factor between [0, 1]. If smaller than 1.0, the code
-            will only use a random subset of the particles, corresponding to
-            the fraction specified
+sample_factor: float
+    subsampling factor between [0, 1]. If smaller than 1.0, the code will only
+    use a random subset of the particles, corresponding to the fraction
+    specified
 
-        box_depth: float
-            physical size of the density cube
+box_depth: float
+    physical size of the density cube
 
-        particle_mass: float
-            mass of a single particle
+particle_mass: float
+    mass of a single particle
 
-        supersampling: int
-            number of sampled points in each volume cell. The density will be
-            averaged over a ``supersampling ** 3`` grid within the volume cell.
-            For example, if set to 1, the density will be evaluated once at the
-            center of each cell. For 2, it will be evaulated on a regular 2x2x2
-            mesh and averaged.
+supersampling: int
+    number of sampled points in each volume cell. The density will be averaged
+    over a ``supersampling ** 3`` grid within the volume cell. For example, if
+    set to 1, the density will be evaluated once at the center of each cell.
+    For 2, it will be evaulated on a regular 2x2x2 mesh and averaged.
 
-        Returns
-        -------
-        rho: np.ndarray
-            the volumetric density map, in units of ``mass / length^3``
-            (shape: ``(grid_dim, grid_dim, grid_dim)``)
-  )Delim",
+Returns
+-------
+rho: np.ndarray
+    the volumetric density map, in units of ``mass / length^3``
+    (shape: ``(grid_dim, grid_dim, grid_dim)``)
+
+)Delim",
         py::arg("particle_pos"),
         py::arg("center"),
         py::arg("grid_dim"),

--- a/src/dtfe.c
+++ b/src/dtfe.c
@@ -374,20 +374,18 @@ double shoot_3d_ray( int th_idx, int *tetra_data, double *nabla, double *particl
 }
 
 void evaluate_3d_ray_on_grid( int th_idx, int *tetra_data, double *nabla, double *particle_data, double x, double y,
-    double offset_z, double box_len_z, int nz, double delta_xy, int *tetra_crossed, double* rho_vector){
+    double offset_z, double box_len_z, int nz, double delta_xy, int *tetra_crossed, unsigned supersampling,
+    double* rho_vector){
   double z;
   double *vert[4];
   double P_enter[3];
   double P_leave[3];
   int enterFace;
   int leaveFace;
-  int is_intersection;
   int is_special_case;
   int perturb_counter;
   double orig[3];
   double dest[3];
-  int tmp;
-  int i;
   double dir[3];
   double plRay[ 6 ];
   plRay[0] = 0.0f;
@@ -397,7 +395,14 @@ void evaluate_3d_ray_on_grid( int th_idx, int *tetra_data, double *nabla, double
   int *tetrahedron;
   int last_th_idx;
 
-  double dz = box_len_z / nz;
+  // space between grid-points
+  const double dz = box_len_z / nz;
+  // space between supersampled points
+  const double dzs = dz / supersampling;
+  const int nzs = nz*supersampling;
+  // supersampling weight
+  const double ss_weight = 1./(supersampling*supersampling*supersampling);
+
   const double max_dist = delta_xy / 2.0;
   const double dist = max_dist / PERTURB_MAX;
 
@@ -429,7 +434,7 @@ void evaluate_3d_ray_on_grid( int th_idx, int *tetra_data, double *nabla, double
     while( tetrahedron[ 4 + leaveFace ] != -1 ) {
       // detect a turn around, and, turn around
       if ( tetrahedron[ 4 + leaveFace ] == last_th_idx ) {
-        tmp = enterFace;
+        int tmp = enterFace;
         enterFace = leaveFace;
         leaveFace = tmp;
         if ( tetrahedron[ 4 + leaveFace ] == -1 )
@@ -484,22 +489,26 @@ void evaluate_3d_ray_on_grid( int th_idx, int *tetra_data, double *nabla, double
       double enter_z = P_enter[ 2 ];
       double leave_z = P_leave[ 2 ];
 
-      // start and past-the-end index of gridpoints along z within tetrahedron
-      int enter_iz = ceil((enter_z - offset_z)/dz);
-      enter_iz = enter_iz < 0 ? 0 : enter_iz;
-      int leave_iz = ceil((leave_z - offset_z)/dz);
-      leave_iz = leave_iz > nz ? nz : leave_iz;
+      // // start and past-the-end index of the (fine) gridpoints along z within tetrahedron
+      int enter_izs = ceil((enter_z - offset_z - dzs/2.)/dzs);
+      enter_izs = enter_izs < 0 ? 0 : enter_izs;
+      int leave_izs = ceil((leave_z - offset_z - dzs/2.)/dzs);
+      leave_izs = leave_izs > nzs ? nzs : leave_izs;
 
-      if(leave_iz > enter_iz) {
+      if(leave_izs > enter_izs) {
         double tetra_rho = particle_data[ tetrahedron[ A ] * 4 + 3 ];
         double nab_tmp = nabla[ th_idx * 3 + 2 ];
         double fixed_part_sum = tetra_rho + \
-            ( nabla[ th_idx * 3  + 0 ] * ( orig[ 0 ] - vert[ 0 ][ 0 ] ) ) + ( nabla[ th_idx * 3 + 1 ] * ( orig[ 1 ] - vert[ 0 ][ 1 ] ) ) - ( nab_tmp * vert[ 0 ][ 2 ] );
-        // printf("  tetra=%10i z_in=%10.4e z_out=%10.4e iz_in=%3i iz_out=%3i\n", *tetra_crossed, enter_z, leave_z, enter_iz, leave_iz);
-        for(int iz=enter_iz; iz < leave_iz; ++iz) {
+            nabla[ th_idx * 3  + 0 ] * ( orig[ 0 ] - vert[ 0 ][ 0 ] ) + \
+            nabla[ th_idx * 3 + 1 ] * ( orig[ 1 ] - vert[ 0 ][ 1 ] ) - \
+            nab_tmp * vert[ 0 ][ 2 ];
+        // printf("  tetra=%10i z_in=%10.4e z_out=%10.4e iz_in=%3i iz_out=%3i\n", *tetra_crossed, enter_z, leave_z, enter_izs/supersampling, leave_izs/supersampling);
+        for(int izs=enter_izs; izs < leave_izs; ++izs) {
+          int iz = izs / supersampling;
+          assert(iz > 0 && iz < nz);
           // z-coordinate of grid-point
-          double z_interp = offset_z + dz * iz;
-          rho_vector[iz] = fixed_part_sum + nab_tmp * z_interp;
+          double z_interp = offset_z + dzs * izs + dzs/2.;
+          rho_vector[iz] += (fixed_part_sum + nab_tmp * z_interp) * ss_weight;
         }
       }
     }
@@ -567,30 +576,27 @@ void compute_density(double *particle_data, int n_particles, int *tetra_data, in
 
   //*******************************************************************************
   // the pixel width
-  double delta_xy = box_len / grid_dim;
+  const double delta_xy = box_len / grid_dim;
 
   // The coordinate offsets of the grid
-  double offset_x = -(box_len/2.0) + center_x;
-  double offset_y = -(box_len/2.0) + center_y;
-  double offset_z = -(box_len_z/2.0) + center_z;
+  const double offset_x = -(box_len/2.0) + center_x;
+  const double offset_y = -(box_len/2.0) + center_y;
+  const double offset_z = -(box_len_z/2.0) + center_z;
 
   // if the MC sample area is bigger than the pixel, keep it, otherwise use the pixel area
   const double sample_scale  = delta_sample > delta_xy ? delta_sample : delta_xy;
   // adjust the offset for MC sampling
   const double sample_offset = delta_sample > delta_xy ? (delta_sample-delta_xy)/2.0 : 0.0;
 
-  int num_threads = 1;
-  int my_thread_id = 1;
 
 #if defined(_OPENMP)
-  #pragma omp parallel \
-  default( none ) \
-  shared( tri_data, tetra_data, particle_data, rho, offset_z, box_len_z, delta_xy, grid_dim, \
-  num_threads, i, offset_x, offset_y, my_thread_id, nabla, tetra_crossed, tetra_crossed_srt ) \
-  private(sub_dim, num_sub_elem )
+  #pragma omp parallel
 {
-  num_threads = omp_get_num_threads();    // for OPENMP update the number of threads
-  my_thread_id = omp_get_thread_num();
+  int num_threads = omp_get_num_threads();    // for OPENMP update the number of threads
+  int my_thread_id = omp_get_thread_num();
+# else
+  int num_threads = 1;
+  int my_thread_id = 1;
 #endif
   int sub_dim = 4; // must be poower of 2
   int num_sub_elem = sub_dim * sub_dim;
@@ -648,7 +654,9 @@ free(tri_data);
 }
 
 void compute_3d_density(double *particle_data, int n_particles, int *tetra_data, int n_tetra, int grid_dim, \
-  double box_len, double *rho, float p_mass, double center_x, double center_y, double center_z) {
+  double box_len, double *rho, float p_mass, double center_x, double center_y, double center_z, unsigned supersampling) {
+
+  assert(supersampling > 0);
 
   // precompute the on-site density values and gradients
   pre_compute_vol(&particle_data, n_particles, tetra_data, n_tetra, p_mass);
@@ -671,43 +679,44 @@ void compute_3d_density(double *particle_data, int n_particles, int *tetra_data,
 
   //*******************************************************************************
   // the pixel width
-  double delta_xy = box_len / grid_dim;
+  const double delta_xy = box_len / grid_dim;
 
   // The coordinate offsets of the grid
-  double offset_x = -(box_len/2.0) + center_x;
-  double offset_y = -(box_len/2.0) + center_y;
-  double offset_z = -(box_len/2.0) + center_z;
+  const double offset_x = -(box_len/2.0) + center_x;
+  const double offset_y = -(box_len/2.0) + center_y;
+  const double offset_z = -(box_len/2.0) + center_z;
 
+  const double ds = delta_xy / supersampling; // supersampling distance
+
+#if defined(_OPENMP)
+  #pragma omp parallel
+{
+  int num_threads = omp_get_num_threads();    // for OPENMP update the number of threads
+  int my_thread_id = omp_get_thread_num();
+
+  #pragma omp for collapse(2)
+#else
   int num_threads = 1;
   int my_thread_id = 1;
-
-#if defined(_OPENMP)
-  #pragma omp parallel \
-  default( none ) \
-  shared( tri_data, tetra_data, particle_data, rho, offset_z, box_len_z, delta_xy, grid_dim, \
-  num_threads, i, offset_x, offset_y, my_thread_id, nabla, tetra_crossed, tetra_crossed_srt ) \
-  private(sub_dim, num_sub_elem )
-{
-  num_threads = omp_get_num_threads();    // for OPENMP update the number of threads
-  my_thread_id = omp_get_thread_num();
 #endif
-#if defined(_OPENMP)
-  #pragma omp for schedule( dynamic, 1 )
-#endif
-
   for(int i=0; i<grid_dim; ++i) {
     for(int j=0; j<grid_dim; ++j) {
-      double x = i*delta_xy + offset_x;
-      double y = j*delta_xy + offset_y;
       size_t index0 = ((i*grid_dim) + j)*grid_dim;
-      int ft=0, start_tri=0;
-      ft=pt_loc_2d(tri_data, particle_data, &start_tri, x, y);
-      int tmp; // the number of tetra intersected
-      // printf("Loop i=%3i j=%3i\n", i, j);
-      evaluate_3d_ray_on_grid(
-        ft, tetra_data, nabla, particle_data,
-        x, y, offset_z, box_len, grid_dim, delta_xy,
-        &tmp, rho + index0);
+
+      // supersampling
+      for(int is=0; is<supersampling; ++is)
+        for(int js=0; js<supersampling; ++js) {
+          double x = i*delta_xy + offset_x + is*ds + ds/2.;
+          double y = j*delta_xy + offset_y + js*ds + ds/2.;
+          int ft=0, start_tri=0;
+          ft=pt_loc_2d(tri_data, particle_data, &start_tri, x, y);
+          int tmp; // the number of tetra intersected
+          // printf("Loop i=%3i j=%3i\n", i, j);
+          evaluate_3d_ray_on_grid(
+            ft, tetra_data, nabla, particle_data,
+            x, y, offset_z, box_len, grid_dim, delta_xy,
+            &tmp, supersampling, rho + index0);
+        }
     }
   }
   #if defined(_OPENMP)

--- a/src/dtfe.h
+++ b/src/dtfe.h
@@ -13,6 +13,9 @@ extern "C" {
 void compute_density(double *particle_data, int n_particles, int *tetra_data, int n_tetra, int grid_dim, \
   double box_len, double box_len_z, double *rho, float p_mass, double center_x, double center_y, double center_z, \
   const int n_mc_samp, const double delta_sample);
+
+void compute_3d_density(double *particle_data, int n_particles, int *tetra_data, int n_tetra, int grid_dim, \
+  double box_len, double *rho, float p_mass, double center_x, double center_y, double center_z);
 #endif
 
 #ifdef __cplusplus

--- a/src/dtfe.h
+++ b/src/dtfe.h
@@ -15,7 +15,7 @@ void compute_density(double *particle_data, int n_particles, int *tetra_data, in
   const int n_mc_samp, const double delta_sample);
 
 void compute_3d_density(double *particle_data, int n_particles, int *tetra_data, int n_tetra, int grid_dim, \
-  double box_len, double *rho, float p_mass, double center_x, double center_y, double center_z);
+  double box_len, double *rho, float p_mass, double center_x, double center_y, double center_z, unsigned supersampling);
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
I added a function for volumetric density estimation to dtfe.c, that also can be accessed through the python interface. Seems to produce reasonable results according to Florian's tests.

In addition, I also set up sphinx documentation for the python module that is automatically built when commits are pushed to the repository. We may need to add an empty ``gh_pages`` branch to the repo.

I simplified the OpenMP pragmas (not explicity declaring the shared and private variables), they are working now too and the CMake script automatically uses OpenMP if available.

I also fixed a bug in the python wrapper for the surface density, where previously particle masses were not adjusted when sampling_factor was below 1.0.