### PR TITLE
Fix Python Build, Update qhull

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,4 +30,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Build Project
         run: |
-          pip install .
+          python -m pip install .
+      - name: Test import
+        run: |
+          cd ~
+          python -c "import pydtfe"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,33 @@
+name: build
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-library:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Build Project
+        uses: threeal/cmake-action@v2.1.0
+  build-python:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Build Project
+        run: |
+          pip install .

--- a/.github/workflows/sphinx.yml
+++ b/.github/workflows/sphinx.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # https://github.com/marketplace/actions/checkout
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           lfs: true
@@ -21,25 +21,13 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.12
       # https://docs.github.com/en/actions/guides/building-and-testing-python#caching-dependencies
       # ^-- How to set up caching for pip on Ubuntu
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-            ${{ runner.os }}-
-      # https://docs.github.com/en/actions/guides/building-and-testing-python#installing-dependencies
-      # ^-- This gives info on installing dependencies with pip
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install numpy
-          python -m pip install Sphinx sphinx-rtd-theme sphinxcontrib-napoleon numpydoc myst-parser
-          python -m pip install .
+          python -m pip install .[docs]
       - name: Debugging information
         run: |
           echo "github.ref:" ${{github.ref}}
@@ -55,7 +43,7 @@ jobs:
           pip list --not-required
           pip list
       # Build
-      - uses: ammaraskar/sphinx-problem-matcher@master
+      - uses: sphinx-doc/sphinx-problem-matcher@master
       - name: Build Sphinx docs
         working-directory: ./docs
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(FetchContent)
 FetchContent_Declare(
     qhull
     GIT_REPOSITORY https://github.com/qhull/qhull.git
-    GIT_TAG 2020.2
+    GIT_TAG v8.0.2
 )
 FetchContent_GetProperties(qhull)
 if(NOT qhull_POPULATED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,14 +16,13 @@ include(FetchContent)
 FetchContent_Declare(
     qhull
     GIT_REPOSITORY https://github.com/qhull/qhull.git
-    GIT_TAG 2015.2
+    GIT_TAG 2020.2
 )
 FetchContent_GetProperties(qhull)
 if(NOT qhull_POPULATED)
-    FetchContent_Populate(qhull)
+    FetchContent_MakeAvailable(qhull)
     # patch incorrect cmake_source_dir in qhull
     execute_process(COMMAND sed -i "s@CMAKE_SOURCE_DIR@CMAKE_CURRENT_SOURCE_DIR@g" ${qhull_SOURCE_DIR}/CMakeLists.txt)
-    add_subdirectory(${qhull_SOURCE_DIR} ${qhull_BINARY_DIR})
 endif()
 
 # load tiff
@@ -31,12 +30,11 @@ include(FetchContent)
 FetchContent_Declare(
     libtiff
     GIT_REPOSITORY https://gitlab.com/libtiff/libtiff.git
-    GIT_TAG v4.3.0
+    GIT_TAG v4.7.0
 )
 FetchContent_GetProperties(libtiff)
 if(NOT libtiff_POPULATED)
-    FetchContent_Populate(libtiff)
-    add_subdirectory(${libtiff_SOURCE_DIR} ${libtiff_BINARY_DIR})
+    FetchContent_MakeAvailable(libtiff)
 endif()
 
 # OpenMP  (if found: OpenMP_FOUND)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,19 @@
+[project]
+name = "pydtfe"
+version = "0.1.1"
+dependencies = [
+    "numpy"
+]
+
+[project.optional-dependencies]
+docs = [
+    "Sphinx",
+    "sphinx-rtd-theme",
+    "sphinxcontrib-napoleon",
+    "numpydoc",
+    "myst-parser"
+]
+
 [build-system]
 requires = [
     "setuptools>=42",
@@ -5,3 +21,4 @@ requires = [
     "cmake>=3.11",
 ]
 build-backend = "setuptools.build_meta"
+

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_STANDARD 17)
 FetchContent_Declare(
     pybind11
     GIT_REPOSITORY https://github.com/pybind/pybind11.git
-    GIT_TAG v2.8.0
+    GIT_TAG v2.13.6
 )
 
 FetchContent_GetProperties(pybind11)


### PR DESCRIPTION
This PR fixes build issues that arises from version issues with qhull. It does the following:

- Updates qhull to version 8.0.2
- Updates CmakeLists + setup.py to remove deprecated calls
- Declares dependencies in pyproject.toml
- Adds github action to test building the library on windows + linux, on several python versions

This PR does not touch anything in the software itself. Everything compiles, so it does not seem that there were any major API changes in the downstream dependencies.

Context: I will be using this software for a project